### PR TITLE
Update blog post about Slack billing increase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "skyfall-site",
+  "type": "module",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro check && astro build",
+    "build:ci": "astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "knip": "knip-bun",
+    "format": "biome format --write",
+    "check": "biome check && bun knip && astro check"
+  },
+  "dependencies": {
+    "@astrojs/check": "^0.9.4",
+    "@astrojs/mdx": "4.2.1",
+    "@astrojs/rss": "^4.0.11",
+    "@astrojs/tailwind": "6.0.1",
+    "@astrojs/vercel": "8.1.3",
+    "@fontsource-variable/inter": "^5.1.1",
+    "@fontsource/fira-code": "^5.1.1",
+    "@inox-tools/sitemap-ext": "^0.3.6",
+    "@skyfall-powered/simple-icons-astro": "^12.4.2",
+    "astro": "5.5.4",
+    "astro-expressive-code": "^0.40.2",
+    "astro-webmanifest": "^1.0.0",
+    "date-fns": "^4.1.0",
+    "lanyard-wrapper": "2.0.1",
+    "lucide-astro": "^0.470.0",
+    "preact": "^10.26.3",
+    "remark-github-blockquote-alert": "^1.3.0",
+    "satori": "^0.12.1",
+    "sharp": "^0.33.5",
+    "tailwindcss": "^3.4.17",
+    "tw-to-css": "^0.0.12"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@catppuccin/tailwindcss": "^0.1.6",
+    "@tailwindcss/typography": "^0.5.16",
+    "@types/node": "^22.13.5",
+    "knip": "^5.45.0",
+    "typescript": "^5.8.2"
+  },
+  "trustedDependencies": ["@sentry/cli", "esbuild", "sharp"]
+}

--- a/src/content/blog/slack.md
+++ b/src/content/blog/slack.md
@@ -26,6 +26,24 @@ The small amount of notice has also been catastrophic for the programs that we r
 
 Anyway, we're moving to Mattermost. This experience has taught us that owning your data is incredibly important, and if you're a small business especially, then I'd advise you move away too.
 
+## Update: We're self-hosting Mattermost!
+
+We've started moving to Mattermost, and we're running it ourselves (ty, AGPLv3). This way, our data belongs to us, and there's no risk of it being taken away. The whole community, including the messages, links, and files, is coming with us, and we're going to keep 11 years of conversations safe. This is a big change, but the right one.  
+
+We're also planning to make Mattermost completely our own: custom clients, themes, bots, features, and more. See some of the hacky stuff we've done here:  
+
+- [Jamcast](https://github.com/jeremy46231/jamcast#jamcast) — share music in a Slack huddle; streams from a cooperative Spotify Jam to a Slack huddle and a higher-quality website  
+- [SlackScan](https://github.com/3kh0/slackscan) — inspired by TgScan; indexes channels and members to show what channels a user is in  
+- [ShipTalkers](https://github.com/SkyfallWasTaken/shiptalkers) — compare Wakatime vs Slack activity  
+- [Fraudpheus](https://github.com/budzioT/fraudpheus) — AI-enhanced support ticket app  
+- [Zeon](https://github.com/NeonGamerBot-QK/slack-zeon) — personal assistant for Slack  
+- [Shrimp Shuffler](https://github.com/hackclub/shrimp-shuffler/) — rotates Slack workspace icons (written in Ruby)  
+- [Prox2](https://github.com/anirudhb/prox2) — anonymous confessions for Slack  
+- [Slack-TUI](https://github.com/espcaa/slack-tui) — terminal-based Slack client  
+- [Lifeboat](https://github.com/hackclub/replit-lifeboat) — export and back up your Repls  
+
+Want to help out? Just [retweet!](https://x.com/arnavcodes/status/1968705010557976663) — it helps a *lot*!  
+
 ---
 
 _This post was rushed out because, well, this has been a shock! If you'd like any additional details then feel free to send me an email._


### PR DESCRIPTION
hi mahad please merge ty mahad
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updates the Slack billing blog post to announce our move to self-hosted Mattermost, with links to related tools and a share call-to-action. Adds package-lock.json to ensure reproducible installs.

- **Dependencies**
  - Add package-lock.json for deterministic builds.

<!-- End of auto-generated description by cubic. -->

