### PR TITLE
cdn more like cdfix

### DIFF
--- a/src/content/blog/spaces-vuln.md
+++ b/src/content/blog/spaces-vuln.md
@@ -216,7 +216,7 @@ main()
 
 I ran the code, reloaded the page, and sure enough, I had admin access:
 
-![A screenshot of Spaces' admin panel](https://hc-cdn.hel1.your-objectstorage.com/s/v3/1dfad3be3d7b7bb1f31d6cd3ed986ed019439b0a_image.png)
+![A screenshot of Spaces' admin panel](https://user-cdn.hackclub-assets.com/019c2588-6c82-7799-96db-682f923205f3/1dfad3be3d7b7bb1f31d6cd3ed986ed019439b0a_image.png)
 
 Very nice.
 


### PR DESCRIPTION
cdn fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the admin panel screenshot URL in the Spaces vulnerability blog post to use `user-cdn.hackclub-assets.com`. This fixes the image not loading from the previous CDN.

<sup>Written for commit ac25eaeefa179299722271c350f457c8dcba0086. Summary will update on new commits. <a href="https://cubic.dev/pr/skyfallwastaken/mahadk.com/pull/19?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post image link to reference a new content delivery network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->